### PR TITLE
Build animated portfolio homepage

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -66,7 +66,7 @@
   background-color: transparent;
   border: none;
   outline: none;
-  cursor: point;
+  cursor: pointer;
 }
 
 .icon {

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -29,7 +29,7 @@ const Header: React.FC = () => {
     <header className={styles.header}>
       <div className={styles.status}>
         <div className={styles.indicator}></div>
-        Available to work!
+        Available for work!
       </div>
       <nav className={styles.nav}>
         <ThemeToggle value={theme} onChange={toggleTheme} />

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, FC } from "react";
-import Link from "next/link";
 import Head from "next/head";
 import Header from "../Header";
 

--- a/components/ThemeToggle/ThemeToggle.tsx
+++ b/components/ThemeToggle/ThemeToggle.tsx
@@ -18,7 +18,7 @@ const ThemeToggle: React.FC<ThemeToggleProps> = ({ value, onChange }) => {
 
   // Toggle the theme when the user clicks the switch
   const handleToggle = () => {
-    const newTheme = value === "light" ? "dark" : "dark";
+    const newTheme = value === "light" ? "dark" : "light";
     setIsTransitioning(true);
     setTimeout(() => {
       onChange(newTheme);

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,11 @@
+declare module "*.module.scss" {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module "*.svg" {
+  import type { FC, SVGProps } from "react";
+
+  const ReactComponent: FC<SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "next",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "type-check": "tsc"
   },

--- a/pages/Home.module.scss
+++ b/pages/Home.module.scss
@@ -1,0 +1,104 @@
+@import "../styles/_variables";
+@import "../styles/_mixins";
+
+.home {
+  min-height: calc(100vh - 5rem);
+  display: grid;
+  grid-template-rows: 1fr auto;
+  padding: clamp(1.5rem, 4vw, 4rem) clamp(1.25rem, 5vw, 5rem) 1.75rem;
+  overflow: hidden;
+}
+
+.hero {
+  @include flex-center;
+  position: relative;
+}
+
+.wordmark {
+  width: min(56vw, 58rem);
+  min-width: 18rem;
+  height: auto;
+  color: theme-var(color-text);
+  overflow: visible;
+}
+
+.frame,
+.curve,
+.rule {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 12;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  vector-effect: non-scaling-stroke;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: draw 1.35s cubic-bezier(0.65, 0, 0.35, 1) forwards;
+}
+
+.frame {
+  animation-delay: var(--delay, 0s);
+}
+
+.curve {
+  animation-delay: var(--delay, 0.15s);
+}
+
+.rule {
+  stroke-width: 10;
+  animation-delay: var(--delay, 0.35s);
+}
+
+.tags {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2vw, 1.8rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: theme-var(color-text);
+  font-size: clamp(0.75rem, 1vw, 0.95rem);
+  font-weight: $font-weight-medium;
+  letter-spacing: 0.08em;
+}
+
+.separator {
+  opacity: 0.9;
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (max-width: $breakpoint-md) {
+  .home {
+    min-height: calc(100svh - 5rem);
+    padding-bottom: 1.25rem;
+  }
+
+  .wordmark {
+    width: min(86vw, 34rem);
+  }
+
+  .tags {
+    gap: 0.65rem;
+    text-align: center;
+  }
+
+  .separator {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frame,
+  .curve,
+  .rule {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,108 @@
-import Link from "next/link";
+import type { CSSProperties } from "react";
 import Layout from "../components/Layout";
+import styles from "./Home.module.scss";
+
+type AnimatedDelay = CSSProperties & { "--delay": string };
+
+const delay = (value: string): AnimatedDelay => ({ "--delay": value });
 
 const IndexPage = () => (
   <Layout title="hdr - Portfolio">
-    <h1>Hello Haider.js 👋</h1>
-    <p>Yayy</p>
+    <section className={styles.home} aria-label="HDR portfolio home">
+      <div className={styles.hero}>
+        <svg
+          className={styles.wordmark}
+          viewBox="0 0 920 360"
+          role="img"
+          aria-labelledby="wordmark-title wordmark-description"
+        >
+          <title id="wordmark-title">hdr</title>
+          <desc id="wordmark-description">
+            Animated geometric line art spelling the letters h, d, and r.
+          </desc>
+
+          <g aria-hidden="true">
+            {/* h */}
+            <path
+              className={styles.frame}
+              style={delay("0s")}
+              pathLength="1"
+              d="M92 318V42H208V318H92Z"
+            />
+            <path
+              className={styles.frame}
+              style={delay("0.12s")}
+              pathLength="1"
+              d="M208 154H318V318H208Z"
+            />
+            <path
+              className={styles.curve}
+              style={delay("0.28s")}
+              pathLength="1"
+              d="M98 210C119 172 157 154 208 154C269 154 318 204 318 266"
+            />
+            <path
+              className={styles.rule}
+              style={delay("0.44s")}
+              pathLength="1"
+              d="M92 266H318"
+            />
+
+            {/* d */}
+            <path
+              className={styles.frame}
+              style={delay("0.26s")}
+              pathLength="1"
+              d="M476 42H592V318H476Z"
+            />
+            <path
+              className={styles.curve}
+              style={delay("0.42s")}
+              pathLength="1"
+              d="M482 154C414 154 360 207 360 267C360 327 414 318 476 318C538 318 592 267 592 207C592 168 544 154 482 154Z"
+            />
+            <path
+              className={styles.rule}
+              style={delay("0.58s")}
+              pathLength="1"
+              d="M476 154V318"
+            />
+
+            {/* r */}
+            <path
+              className={styles.frame}
+              style={delay("0.52s")}
+              pathLength="1"
+              d="M642 154H758V318H642Z"
+            />
+            <path
+              className={styles.curve}
+              style={delay("0.68s")}
+              pathLength="1"
+              d="M648 210C668 174 706 154 758 154C820 154 870 204 870 266H758"
+            />
+            <path
+              className={styles.rule}
+              style={delay("0.84s")}
+              pathLength="1"
+              d="M642 266H870M758 154V318"
+            />
+          </g>
+        </svg>
+      </div>
+
+      <ul className={styles.tags} aria-label="Professional roles">
+        <li>Web Developer</li>
+        <li className={styles.separator} aria-hidden="true">
+          |
+        </li>
+        <li>JavaScript Enthusiast</li>
+        <li className={styles.separator} aria-hidden="true">
+          |
+        </li>
+        <li>UI/UX Designer</li>
+      </ul>
+    </section>
   </Layout>
 );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Motivation
- Finish the unfinished homepage by adding a presentational hero and simple branding animation so the site is no longer a placeholder. 
- Provide an accessible, responsive SVG wordmark with a draw animation and reduced-motion support to match the intended portfolio design. 
- Make small UX/typing fixes and ensure the repo's existing SVG webpack integration continues to build under newer Next.js versions. 

### Description
- Replaced the placeholder index with a responsive hero that renders an animated geometric `hdr` SVG wordmark and role labels (`pages/index.tsx`, `pages/Home.module.scss`).
- Added homepage SCSS implementing draw-on-line animations, responsive layout, and `prefers-reduced-motion` support (`pages/Home.module.scss`).
- Fixed header copy and button cursor, corrected theme toggle back-switching logic, and removed an unused import (`components/Header/*`, `components/ThemeToggle/*`, `components/Layout/Layout.tsx`).
- Added TypeScript declarations for SCSS modules and SVG imports and adjusted JSX compiler setting to the automatic runtime; forced webpack for the build script to preserve the custom SVG loader (`declarations.d.ts`, `tsconfig.json`, `package.json`).

### Testing
- Ran `npm run type-check` which completed successfully with no type errors. 
- Ran `npm run build` which completed successfully but emitted SASS `@import` deprecation warnings and a TypeScript version recommendation; the build output finished and static pages were generated. 
- Started the production server with `./node_modules/.bin/next start --hostname 127.0.0.1` and verified the root route returned `HTTP/1.1 200 OK` via `curl -I http://127.0.0.1:3000/`.
- Attempted `npx playwright` for screenshot tooling which failed to install due to registry `403 Forbidden`, but this is unrelated to the site build and start checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031294a204832eaea56410a080cfcc)