### PR TITLE
Improve mobile header and hero responsiveness

### DIFF
--- a/components/FullPageScroll/FullPageScroll.module.scss
+++ b/components/FullPageScroll/FullPageScroll.module.scss
@@ -96,3 +96,35 @@ $panel-h: calc(100vh - 5rem);
     padding: 2rem $spacing-lg;
   }
 }
+
+@include respond-below($breakpoint-sm) {
+  .dots {
+    right: $spacing-md;
+    top: auto;
+    bottom: $spacing-lg;
+    transform: none;
+    gap: 0.65rem;
+  }
+
+  .dot {
+    gap: 0;
+  }
+
+  .dotLabel {
+    display: none;
+  }
+
+  .pip {
+    width: 6px;
+    height: 6px;
+    border-width: 1px;
+
+    .dot[data-active="true"] & {
+      height: 16px;
+    }
+  }
+
+  .panel {
+    padding: 1.5rem $spacing-md 2.5rem;
+  }
+}

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -86,7 +86,7 @@
 
 @include mixins.respond-below(variables.$breakpoint-sm) {
   .header {
-    padding: 0 variables.$spacing-md;
+    padding: 0 clamp(variables.$spacing-lg, 5vw, variables.$spacing-xl);
   }
 
   .status {

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -26,6 +26,10 @@
     position: relative;
   }
 
+  .statusText {
+    display: inline;
+  }
+
   .indicator::after {
     content: "";
     position: absolute;
@@ -66,7 +70,7 @@
   background-color: transparent;
   border: none;
   outline: none;
-  cursor: point;
+  cursor: pointer;
 }
 
 .icon {
@@ -78,4 +82,39 @@
 .email {
   font-size: variables.$font-size-md;
   text-decoration: none;
+}
+
+@include mixins.respond-below(variables.$breakpoint-sm) {
+  .header {
+    padding: 0 variables.$spacing-md;
+  }
+
+  .status {
+    min-width: 1.5rem;
+
+    .indicator {
+      margin-right: 0;
+    }
+
+    .statusText {
+      display: none;
+    }
+  }
+
+  .nav {
+    gap: variables.$spacing-md;
+  }
+
+  .downloadButton {
+    display: none;
+  }
+
+  .icon {
+    width: 1.1rem;
+    height: 1.1rem;
+  }
+
+  .email {
+    font-size: variables.$font-size-sm;
+  }
 }

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -29,7 +29,7 @@ const Header: React.FC = () => {
     <header className={styles.header}>
       <div className={styles.status}>
         <div className={styles.indicator}></div>
-        Available to work!
+        <span className={styles.statusText}>Available to work!</span>
       </div>
       <nav className={styles.nav}>
         <ThemeToggle value={theme} onChange={toggleTheme} />

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -90,7 +90,7 @@
   }
 
   .logo {
-    width: 80vw;
+    width: 120vw;
     max-height: 46vh;
   }
 

--- a/components/Hero/Hero.module.scss
+++ b/components/Hero/Hero.module.scss
@@ -17,9 +17,9 @@
 }
 
 .logo {
-  width: min(66vw, 780px);
+  width: min(72vw, 860px);
   aspect-ratio: 1440 / 1024;
-  max-height: 52vh;
+  max-height: 58vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -38,8 +38,8 @@
 }
 
 .hintText {
-  font-size: 0.66rem;
-  letter-spacing: 0.28em;
+  font-size: 0.6rem;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
   font-weight: 300;
 }
@@ -47,6 +47,11 @@
 .arrow {
   display: flex;
   animation: heroBob 2s ease-in-out infinite;
+
+  svg {
+    width: 0.95rem;
+    height: 0.95rem;
+  }
 }
 
 @keyframes heroBob {
@@ -73,4 +78,45 @@
 
 .slash {
   opacity: 0.35;
+}
+
+.optionalTitle {
+  display: contents;
+}
+
+@include respond-below($breakpoint-sm) {
+  .center {
+    gap: 1.65rem;
+  }
+
+  .logo {
+    width: 80vw;
+    max-height: 46vh;
+  }
+
+  .hint {
+    gap: 0.4rem;
+  }
+
+  .hintText {
+    font-size: 0.54rem;
+    letter-spacing: 0.18em;
+  }
+
+  .arrow svg {
+    width: 0.82rem;
+    height: 0.82rem;
+  }
+
+  .titles {
+    gap: 1rem;
+    font-size: 0.64rem;
+    letter-spacing: 0.24em;
+  }
+}
+
+@media only screen and (max-width: 23.5rem) {
+  .optionalTitle {
+    display: none;
+  }
 }

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -43,10 +43,10 @@ const Hero: React.FC = () => {
       </div>
       <div className={styles.titles} data-reveal>
         <span>Engineer</span>
-        <span className={styles.slash}>/</span>
-        <span>Enthusiast</span>
-        <span className={styles.slash}>/</span>
-        <span>Designer</span>
+        <span className={styles.optionalTitle}>
+          <span className={styles.slash}>/</span>
+          <span>Designer</span>
+        </span>
       </div>
     </div>
   );

--- a/components/ThemeToggle/ThemeToggle.module.scss
+++ b/components/ThemeToggle/ThemeToggle.module.scss
@@ -62,3 +62,23 @@
   width: 1.25rem;
   height: 1.25rem;
 }
+
+@include mixins.respond-below(variables.$breakpoint-sm) {
+  .ThemeToggle {
+    .lineLeft,
+    .lineRight,
+    &.light .lineLeft,
+    &.light .lineRight,
+    &.dark .lineLeft,
+    &.dark .lineRight {
+      width: 0;
+      height: 0;
+      margin: 0;
+    }
+  }
+
+  .icon {
+    width: 1.1rem;
+    height: 1.1rem;
+  }
+}


### PR DESCRIPTION
### Motivation

- Make the site usable on small phones (targeting iPhone SE) by simplifying the header and tightening UI elements for narrow viewports.
- Reduce visual noise on mobile by hiding non-essential text/icons and converting complex controls to icon-only interactions.
- Improve the hero section sizing and the section navigation UX for small screens so key content remains visible and tappable.

### Description

- Header: hide the availability text on small screens while keeping the animated green indicator, hide the resume download icon on mobile, reduce icon sizes and spacing, and tweak header padding (changes in `components/Header/Header.tsx` and `components/Header/Header.module.scss`).
- Theme toggle: collapse the decorative left/right bars at small breakpoints so the control is icon-only on phones (changes in `components/ThemeToggle/ThemeToggle.module.scss`).
- Hero: enlarge the Lottie area on desktop and set the mobile Lottie to `80vw`, reduce the scroll hint size, and make the titles read `Engineer / Designer` with an extra rule that collapses to just `Engineer` on very small viewports (changes in `components/Hero/Hero.tsx` and `components/Hero/Hero.module.scss`).
- Full-page dots: move the vertical dot navigation to the bottom-right on small screens, hide labels, and reduce pip sizes for touch-friendly targets (changes in `components/FullPageScroll/FullPageScroll.module.scss`).

### Testing

- `yarn type-check` was run and failed due to missing TypeScript declarations for SCSS module and SVG imports (repository issue unrelated to these style changes).
- `yarn build` was run and completed successfully but emitted existing Sass `@import` deprecation warnings and an outdated Browserslist warning; build artifacts were generated.
- Playwright/browser screenshot tooling could not be used in this environment because `npx playwright` failed to install (npm registry 403), so visual confirmation on an actual iPhone SE emulator was not captured automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5409653f5c832eb17cb6d989488660)