### PR TITLE
Improve responsive panels and real LinkedIn recommendations

### DIFF
--- a/components/About/About.module.scss
+++ b/components/About/About.module.scss
@@ -1,6 +1,8 @@
 @import "../../styles/variables";
 @import "../../styles/mixins";
 
+$short-panel-height: 760px;
+
 .wrap {
   max-width: 1200px;
   margin: 0 auto;
@@ -94,4 +96,32 @@
 .detail {
   font-size: 0.85rem;
   color: theme-var(color-muted);
+}
+
+@media (max-height: $short-panel-height) {
+  .eyebrow {
+    margin-bottom: 1rem;
+  }
+
+  .grid {
+    gap: 2rem;
+  }
+
+  .heading {
+    margin-bottom: 1rem;
+    font-size: clamp(1.6rem, 3vw, 2.4rem);
+  }
+
+  .lead {
+    margin-bottom: 0.8rem;
+    font-size: 1rem;
+  }
+
+  .body {
+    font-size: 0.94rem;
+  }
+
+  .side {
+    gap: 1.2rem;
+  }
 }

--- a/components/FullPageScroll/FullPageScroll.module.scss
+++ b/components/FullPageScroll/FullPageScroll.module.scss
@@ -2,6 +2,7 @@
 @import "../../styles/mixins";
 
 $panel-h: calc(100vh - 5rem);
+$short-panel-height: 760px;
 
 .viewport {
   height: $panel-h;
@@ -126,5 +127,12 @@ $panel-h: calc(100vh - 5rem);
 
   .panel {
     padding: 1.5rem $spacing-md 2.5rem;
+  }
+}
+
+@media (max-height: $short-panel-height) {
+  .panel {
+    justify-content: flex-start;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
## Summary

- Top-align full-page panels on short viewport heights and allow internal vertical scrolling.
- Tighten the About section spacing and type scale under the same short-height breakpoint.
- Replace placeholder recommendations with exported real LinkedIn recommendation data.
- Render reviewer avatars, relationship context, titles, and LinkedIn profile links in the recommendations carousel.

## Why

The About section could overflow both above and below the viewport because full-page panels were vertically centered inside a fixed-height sticky/snap viewport. The recommendations section was also using placeholder/public JSON data instead of the richer exported LinkedIn recommendations.

## Validation

- `yarn build`
- Local dev server preview at `http://localhost:3000`